### PR TITLE
feat: 플래시 카드 화면, 결과 화면

### DIFF
--- a/app/(tabs)/study.tsx
+++ b/app/(tabs)/study.tsx
@@ -2,6 +2,7 @@ import LevelCard from '@/components/level-card';
 import { TodoList } from '@/components/TodoList/todo-list';
 import { colors } from '@/constants/colors';
 import { LinearGradient } from 'expo-linear-gradient';
+import { useRouter } from 'expo-router';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import Arrow from '../../assets/images/arrow.svg';
 import FlashCardIcon from '../../assets/images/flash-card.svg';
@@ -9,6 +10,8 @@ import SeedCharacter from '../../assets/images/seed.svg';
 import { ProgressCard } from '../../components/TodoList/todo-list-progress';
 
 export default function StudyScreen() {
+  const router = useRouter();
+
   return (
     <ScrollView style={styles.container}>
       <LinearGradient
@@ -33,7 +36,7 @@ export default function StudyScreen() {
       <View style={styles.todoSection}>
         <Text style={styles.sectionTitle}>오늘의 학습 투두</Text>
         <View style={styles.todoList}>
-          <TodoList icon={<FlashCardIcon />} />
+          <TodoList icon={<FlashCardIcon />} onPress={() => router.push('/flash-card')} />
           <Arrow width={16} height={16} color={colors.primary[500]} />
           <ProgressCard icon={<FlashCardIcon />} />
           <Arrow width={16} height={16} color={colors.grayscale[300]} />

--- a/app/flash-card.tsx
+++ b/app/flash-card.tsx
@@ -1,0 +1,161 @@
+import Button from '@/components/buttons/Button';
+import ListeningButton from '@/components/buttons/ListeningButton';
+import FlashCard from '@/components/flash-card';
+import LearningCompleteScreen from '@/components/learning/LearningCompleteScreen';
+import CommonStackScreen from '@/components/navigation/CommonStackScreen';
+import { colors } from '@/constants/colors';
+import { useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import BottomResult from '../components/quiz/bottom-result';
+import ProgressBar from '../components/TodoList/progressBar';
+type SpeakingState = 'idle' | 'recording' | 'result';
+type ResultState = 'correct' | 'incorrect';
+
+const cards = [
+  {
+    front: 'Apple',
+    back: {
+      meaning: '사과',
+      partOfSpeech: '명사',
+      pronunciation: '[aepl]',
+    },
+  },
+  {
+    front: 'Banana',
+    back: {
+      meaning: '바나나',
+      partOfSpeech: '명사',
+      pronunciation: '[banana]',
+    },
+  },
+  {
+    front: 'Study',
+    back: {
+      meaning: '공부하다',
+      partOfSpeech: '동사',
+      pronunciation: '[stuh-dee]',
+    },
+  },
+];
+
+export default function FlashCardScreen() {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [speakingState, setSpeakingState] = useState<SpeakingState>('idle');
+  const [result, setResult] = useState<ResultState | null>(null);
+  const [correctCount, setCorrectCount] = useState(0);
+  const [isFinished, setIsFinished] = useState(false);
+
+  const currentCard = cards[currentIndex];
+  const progressValue = Math.round(((currentIndex + 1) / cards.length) * 100);
+  const isLastCard = currentIndex === cards.length - 1;
+
+  // 삭제 예정: AI 음성 인식 로직이 구현되면 해당 함수를 호출해 결과를 받아오도록 수정할 예정입니다.
+  const handleSpeak = async () => {
+    setSpeakingState('recording');
+    try {
+      const aiResult = await recognizePronunciation();
+      setResult(aiResult);
+      setSpeakingState('result');
+    } catch {
+      setSpeakingState('idle');
+    }
+  };
+
+  const handleNext = () => {
+    if (result === 'correct') {
+      setCorrectCount((prev) => prev + 1);
+    }
+
+    setSpeakingState('idle');
+    setResult(null);
+
+    if (isLastCard) {
+      setIsFinished(true);
+      return;
+    }
+
+    setCurrentIndex((prev) => prev + 1);
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setSpeakingState('idle');
+    setResult(null);
+    setCorrectCount(0);
+    setIsFinished(false);
+  };
+
+  if (isFinished) {
+    return (
+      <LearningCompleteScreen
+        title="시네츄르가 응원할게"
+        wordsLearned={cards.length}
+        xpEarned={correctCount * 10}
+        onButtonPress={handleRestart}
+      />
+    );
+  }
+
+  return (
+    <>
+      <CommonStackScreen title="플래시 카드" subtitle={`${currentIndex + 1} / ${cards.length}`} />
+      <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+        <ProgressBar progressValue={progressValue}  />
+        <View style={styles.cardWrapper}>
+          <View style={styles.listeningButtonRow}>
+            <ListeningButton onPress={() => {}} />
+          </View>
+          <FlashCard key={currentCard.front} front={currentCard.front} back={currentCard.back} />
+        </View>
+
+        <Text style={styles.hint}>카드를 탭해서 단어보기</Text>
+
+        <Button
+          variant="speaking"
+          title={speakingState === 'recording' ? '듣는 중...' : '말해보기'}
+          onPress={handleSpeak}
+        />
+      </ScrollView>
+
+      {speakingState === 'result' && result && (
+        <BottomResult
+          title={result === 'correct' ? '정확해요! 🎉' : '다시 해볼까요?'}
+          subTitle={result === 'correct' ? '발음이 정확합니다.' : '발음을 다시 확인해보세요.'}
+          state={result}
+          buttonTitle={isLastCard ? '결과 보기' : '다음 문제'}
+          onNext={handleNext}
+        />
+      )}
+    </>
+  );
+}
+
+async function recognizePronunciation(): Promise<ResultState> {
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  return Math.random() > 0.5 ? 'correct' : 'incorrect';
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F1FBFF',
+  },
+  content: {
+    padding: 25,
+    gap: 24,
+  },
+  cardWrapper: {
+    gap: 5,
+  },
+  listeningButtonRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    paddingRight: 10,
+  },
+  hint: {
+    color: colors.grayscale[400],
+    fontSize: 15,
+    fontWeight: '500',
+    textAlign: 'center',
+  },
+});

--- a/assets/bg.svg
+++ b/assets/bg.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="357" height="354" viewBox="0 0 357 354" fill="none">
+  <g filter="url(#filter0_f_527_2187)">
+    <path d="M106.294 20.3697C193.977 -20.1017 297.351 17.0537 337.187 103.359C377.022 189.664 338.234 292.436 250.551 332.908C162.868 373.379 59.4941 336.224 19.6587 249.919C-20.1767 163.614 18.6113 60.8411 106.294 20.3697Z" fill="url(#paint0_radial_527_2187)"/>
+  </g>
+  <defs>
+    <filter id="filter0_f_527_2187" x="0" y="0" width="356.846" height="353.277" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+      <feGaussianBlur stdDeviation="2" result="effect1_foregroundBlur_527_2187"/>
+    </filter>
+    <radialGradient id="paint0_radial_527_2187" cx="0" cy="0" r="1" gradientTransform="matrix(145.891 -154.689 154.54 142.545 172.45 217.218)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E2FDDA"/>
+      <stop offset="1" stop-color="#D0F2FB"/>
+    </radialGradient>
+  </defs>
+</svg>

--- a/components/TodoList/todo-list.tsx
+++ b/components/TodoList/todo-list.tsx
@@ -1,5 +1,5 @@
 import { colors } from '@/constants/colors';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import CheckIcon from '../../assets/images/check.svg';
 import LockIcon from '../../assets/images/lock.svg';
 import { IconBox } from './todo-list-icon-box';
@@ -11,11 +11,16 @@ export function TodoList(props: TodoListProps) {
   return <DoneCard {...props} />;
 }
 
-function DoneCard({ title = '플래시 카드', subtitle = '모두 완료', xp = 20, icon, completed = 'done' }: TodoListProps) {
+function DoneCard({ title = '플래시 카드', subtitle = '모두 완료', xp = 20, icon, completed = 'done', onPress }: TodoListProps) {
   const isDone = completed === 'done';
 
   return (
-    <View style={[styles.container, !isDone && styles.disabledContainer]}>
+    <TouchableOpacity
+      style={[styles.container, !isDone && styles.disabledContainer]}
+      onPress={onPress}
+      activeOpacity={0.8}
+      disabled={!isDone}
+    >
       <View style={styles.left}>
         <IconBox icon={icon} color={isDone ? colors.primary[100] : colors.grayscale[200]} />
         <View style={styles.textContainer}>
@@ -26,7 +31,7 @@ function DoneCard({ title = '플래시 카드', subtitle = '모두 완료', xp =
       <View>
         {!isDone ? <LockIcon width={50} height={50} /> : <CheckIcon width={40} height={40} />}
       </View>
-    </View>
+    </TouchableOpacity>
   );
 }
 

--- a/components/learning/LearningCompleteScreen.tsx
+++ b/components/learning/LearningCompleteScreen.tsx
@@ -1,0 +1,138 @@
+import Button from '@/components/buttons/Button';
+import CommonStackScreen from '@/components/navigation/CommonStackScreen';
+import { colors } from '@/constants/colors';
+import { StyleSheet, Text, View } from 'react-native';
+import BgBlob from '../../assets/bg.svg';
+import SeedCharacter from '../../assets/images/seed.svg';
+
+type LearningCompleteScreenProps = {
+  headerTitle?: string;
+  title: string;
+  wordsLearned: number;
+  xpEarned: number;
+  buttonTitle?: string;
+  onButtonPress: () => void;
+};
+
+export default function LearningCompleteScreen({
+  headerTitle = '학습 완료',
+  title,
+  wordsLearned,
+  xpEarned,
+  buttonTitle = '계속하기',
+  onButtonPress,
+}: LearningCompleteScreenProps) {
+  return (
+    <>
+      <CommonStackScreen title={headerTitle} />
+      <View style={styles.container}>
+        <BgBlob width={350} height={340} style={styles.bubbleTopLeft} />
+        <BgBlob width={140} height={140} style={styles.bubbleTopRight} />
+        <BgBlob width={153} height={153} style={styles.bubbleBottomLeft} />
+        <BgBlob width={500} height={500} style={styles.bubbleBottomRight} />
+
+        <View style={styles.content}>
+          <Text style={styles.title}>{title}</Text>
+
+          <View style={styles.badge}>
+            <Text style={styles.badgeText}>🔥 학습 완료</Text>
+          </View>
+
+          <SeedCharacter width={220} height={220} style={styles.character} />
+
+          <View style={styles.statsRow}>
+            <View style={styles.statItem}>
+              <Text style={styles.statNumber}>{wordsLearned}</Text>
+              <Text style={styles.statLabel}>{'오늘배운\n단어'}</Text>
+            </View>
+            <View style={styles.statItem}>
+              <Text style={styles.statNumber}>{xpEarned}</Text>
+              <Text style={styles.statLabel}>{'오늘 얻은\nXP'}</Text>
+            </View>
+          </View>
+        </View>
+
+        <Button title={buttonTitle} onPress={onButtonPress} />
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F1FBFF',
+    justifyContent: 'space-between',
+    padding: 25,
+    overflow: 'hidden',
+  },
+  bubbleTopLeft: {
+    position: 'absolute',
+    top: -80,
+    left: -80,
+  },
+  bubbleTopRight: {
+    position: 'absolute',
+    top: 60,
+    right: -100,
+    transform: [{ rotate: '120deg' }],
+  },
+  bubbleBottomLeft: {
+    position: 'absolute',
+    bottom: 80,
+    left: -100,
+    transform: [{ rotate: '220deg' }],
+  },
+  bubbleBottomRight: {
+    position: 'absolute',
+    bottom: -300,
+    right: -300,
+    transform: [{ rotate: '45deg' }],
+  },
+  content: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    gap: 20,
+  },
+  title: {
+    color: colors.grayscale[900],
+    fontSize: 26,
+    fontWeight: '800',
+    textAlign: 'center',
+  },
+  badge: {
+    backgroundColor: '#FFD6CC',
+    paddingHorizontal: 20,
+    paddingVertical: 8,
+    borderRadius: 20,
+  },
+  badgeText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#333',
+  },
+  character: {
+    marginVertical: 8,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    gap: 48,
+    marginTop: 8,
+  },
+  statItem: {
+    alignItems: 'center',
+    gap: 4,
+  },
+  statNumber: {
+    fontSize: 52,
+    fontWeight: '800',
+    color: colors.grayscale[900],
+  },
+  statLabel: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: colors.grayscale[500],
+    textAlign: 'center',
+  },
+});

--- a/components/navigation/CommonStackScreen.tsx
+++ b/components/navigation/CommonStackScreen.tsx
@@ -1,0 +1,78 @@
+import { colors } from '@/constants/colors';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { router, Stack } from 'expo-router';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+type CommonStackScreenProps = {
+  title: string;
+  subtitle?: string;
+  backgroundColor?: string;
+};
+
+export default function CommonStackScreen({
+  title,
+  subtitle,
+  backgroundColor = '#F1FBFF',
+}: CommonStackScreenProps) {
+  return (
+    <Stack.Screen
+      options={{
+        headerShadowVisible: false,
+        headerStyle: {
+          backgroundColor,
+        },
+        headerTitle: () => (
+          <View style={styles.headerTitle}>
+            <Text style={styles.headerTitleText}>{title}</Text>
+            {subtitle ? <Text style={styles.headerSubTitle}>{subtitle}</Text> : null}
+          </View>
+        ),
+        headerLeft: () => (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="뒤로가기"
+            hitSlop={12}
+            onPress={() => router.back()}
+            style={styles.headerIconButton}
+          >
+            <MaterialIcons name="arrow-back-ios-new" size={22} color={colors.grayscale[800]} />
+          </Pressable>
+        ),
+        headerRight: () => (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="닫기"
+            hitSlop={12}
+            onPress={() => router.back()}
+            style={styles.headerIconButton}
+          >
+            <MaterialIcons name="close" size={24} color={colors.grayscale[800]} />
+          </Pressable>
+        ),
+      }}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  headerTitle: {
+    alignItems: 'center',
+    gap: 2,
+  },
+  headerTitleText: {
+    color: colors.grayscale[900],
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  headerSubTitle: {
+    color: colors.primary[700],
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  headerIconButton: {
+    alignItems: 'center',
+    height: 40,
+    justifyContent: 'center',
+    width: 40,
+  },
+});

--- a/components/quiz/bottom-result.tsx
+++ b/components/quiz/bottom-result.tsx
@@ -6,21 +6,21 @@ type BottomResultProps = {
     title: string;
     subTitle: string;
     state: 'correct' | 'incorrect';
+    buttonTitle?: string;
+    onNext: () => void;
 }
-const BottomResult = ({title, subTitle, state}: BottomResultProps) => {
+const BottomResult = ({title, subTitle, state, buttonTitle = '다음 문제', onNext}: BottomResultProps) => {
     return(
-        <View style={[styles.container, state == "incorrect" && {backgroundColor: '#FFECEC'}]}>
+        <View style={[styles.container, state === "incorrect" && {backgroundColor: '#FFECEC'}]}>
            <View style={{gap: 4, paddingLeft: 11}}>
-                <Text style={[styles.title, state == "incorrect" && {color: '#FF3131'}]}>
+                <Text style={[styles.title, state === "incorrect" && {color: '#FF3131'}]}>
                     {title}
                 </Text>
-                <Text style={[styles.subTitle, state == "incorrect" && {color: '#FF3131'}]}>
+                <Text style={[styles.subTitle, state === "incorrect" && {color: '#FF3131'}]}>
                     {subTitle}
                 </Text>
            </View>
-            <Button title={'다음 문제'} onPress={function (): void {
-                throw new Error('Function not implemented.');
-            } } 
+            <Button title={buttonTitle} onPress={onNext} 
             variant={state === "incorrect" ? "incorrect" : "primary"}
             />
         </View>


### PR DESCRIPTION
## 📝 작업 내용
- 플래시 카드 학습 화면과 학습 완료 화면을 추가했습니다.

---

## 🔄 변경 사항
- 스터디 탭의 플래시 카드 투두 클릭 시 `/flash-card` 화면으로 이동하도록 연결
- 플래시 카드 진행률, 말하기 상태, 정답/오답 결과 바텀시트 흐름 구현
- 학습 완료 화면 추가 및 학습 단어 수/획득 XP 표시
- 공통 스택 헤더 컴포넌트 추가
- `BottomResult` 컴포넌트에 버튼 타이틀과 다음 동작 핸들러 props 추가
- `TodoList` 카드를 터치 가능한 컴포넌트로 변경

---

## 🔗 관련 이슈
Closes #9 
