### PR TITLE
feat: 예문학습하기 화면

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -23,6 +23,12 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="quiz"
+        options={{
+          href: null,
+        }}
+      />
+      <Tabs.Screen
         name="home"
         options={{
           tabBarIcon: ({ color }) => <IconSymbol size={40} name="house.fill" color={color} />,

--- a/app/(tabs)/quiz.tsx
+++ b/app/(tabs)/quiz.tsx
@@ -38,13 +38,9 @@ export default function StudyScreen() {
         <View style={styles.todoList}>
           <TodoList icon={<FlashCardIcon />} onPress={() => router.push('/flash-card')} />
           <Arrow width={16} height={16} color={colors.primary[500]} />
-          <ProgressCard
-            title="예문 학습하기"
-            icon={<FlashCardIcon />}
-            onPress={() => router.push('/example-sentence')}
-          />
+          <ProgressCard icon={<FlashCardIcon />} />
           <Arrow width={16} height={16} color={colors.grayscale[300]} />
-          <TodoList title="퀴즈" icon={<FlashCardIcon />} completed="disabled" />
+          <TodoList icon={<FlashCardIcon />} completed="disabled" />
         </View>
       </View>
     </ScrollView>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -15,6 +15,8 @@ export default function RootLayout() {
     <>
        <Stack>
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="flash-card" options={{ headerShown: false }} />
+          <Stack.Screen name="example-sentence" options={{ headerShown: false }} />
         </Stack>
         <StatusBar style="auto" />
     </>

--- a/app/example-sentence.tsx
+++ b/app/example-sentence.tsx
@@ -1,0 +1,159 @@
+import Button from '@/components/buttons/Button';
+import ListeningButton from '@/components/buttons/ListeningButton';
+import ExampleCard from '@/components/example-card';
+import LearningCompleteScreen from '@/components/learning/LearningCompleteScreen';
+import CommonStackScreen from '@/components/navigation/CommonStackScreen';
+import { colors } from '@/constants/colors';
+import { useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import BottomResult from '../components/quiz/bottom-result';
+import ProgressBar from '../components/TodoList/progressBar';
+
+type SpeakingState = 'idle' | 'recording' | 'result';
+type ResultState = 'correct' | 'incorrect';
+
+const examples = [
+  {
+    sentence: 'I eat an apple every morning.',
+    keyword: 'apple',
+    translation: '나는 매일 아침 사과를 먹는다.',
+  },
+  {
+    sentence: 'She likes to study English at the library.',
+    keyword: 'study',
+    translation: '그녀는 도서관에서 영어 공부하는 것을 좋아한다.',
+  },
+  {
+    sentence: 'The banana is yellow and sweet.',
+    keyword: 'banana',
+    translation: '바나나는 노랗고 달콤하다.',
+  },
+];
+
+export default function ExampleSentenceScreen() {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [speakingState, setSpeakingState] = useState<SpeakingState>('idle');
+  const [result, setResult] = useState<ResultState | null>(null);
+  const [correctCount, setCorrectCount] = useState(0);
+  const [isFinished, setIsFinished] = useState(false);
+
+  const currentExample = examples[currentIndex];
+  const progressValue = Math.round(((currentIndex + 1) / examples.length) * 100);
+  const isLastCard = currentIndex === examples.length - 1;
+
+  // 삭제 예정: AI 음성 인식 로직이 구현되면 해당 함수를 호출해 결과를 받아오도록 수정할 예정입니다.
+  const handleSpeak = async () => {
+    setSpeakingState('recording');
+    try {
+      const aiResult = await recognizePronunciation();
+      setResult(aiResult);
+      setSpeakingState('result');
+    } catch {
+      setSpeakingState('idle');
+    }
+  };
+
+  const handleNext = () => {
+    if (result === 'correct') {
+      setCorrectCount((prev) => prev + 1);
+    }
+
+    setSpeakingState('idle');
+    setResult(null);
+
+    if (isLastCard) {
+      setIsFinished(true);
+      return;
+    }
+
+    setCurrentIndex((prev) => prev + 1);
+  };
+
+  const handleRestart = () => {
+    setCurrentIndex(0);
+    setSpeakingState('idle');
+    setResult(null);
+    setCorrectCount(0);
+    setIsFinished(false);
+  };
+
+  if (isFinished) {
+    return (
+      <LearningCompleteScreen
+        title="시네츄르가 응원할게"
+        wordsLearned={examples.length}
+        learnedLabel={'오늘배운\n예문'}
+        xpEarned={correctCount * 10}
+        onButtonPress={handleRestart}
+      />
+    );
+  }
+
+  return (
+    <>
+      <CommonStackScreen title="예문 학습하기" subtitle={`${currentIndex + 1} / ${examples.length}`} />
+      <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+        <ProgressBar progressValue={progressValue} />
+        <View style={styles.cardWrapper}>
+          <View style={styles.listeningButtonRow}>
+            <ListeningButton onPress={() => {}} />
+          </View>
+          <ExampleCard
+            key={currentIndex}
+            sentence={currentExample.sentence}
+            keyword={currentExample.keyword}
+            translation={currentExample.translation}
+          />
+        </View>
+
+        <Text style={styles.hint}>카드를 탭해서 해석 보기</Text>
+
+        <Button
+          variant="speaking"
+          title={speakingState === 'recording' ? '듣는 중...' : '말해보기'}
+          onPress={handleSpeak}
+        />
+      </ScrollView>
+
+      {speakingState === 'result' && result && (
+        <BottomResult
+          title={result === 'correct' ? '정확해요! 🎉' : '다시 해볼까요?'}
+          subTitle={result === 'correct' ? '발음이 정확합니다.' : '발음을 다시 확인해보세요.'}
+          state={result}
+          buttonTitle={isLastCard ? '결과 보기' : '다음 문제'}
+          onNext={handleNext}
+        />
+      )}
+    </>
+  );
+}
+
+async function recognizePronunciation(): Promise<ResultState> {
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  return Math.random() > 0.5 ? 'correct' : 'incorrect';
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F1FBFF',
+  },
+  content: {
+    padding: 25,
+    gap: 24,
+  },
+  cardWrapper: {
+    gap: 5,
+  },
+  listeningButtonRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    paddingRight: 10,
+  },
+  hint: {
+    color: colors.grayscale[400],
+    fontSize: 15,
+    fontWeight: '500',
+    textAlign: 'center',
+  },
+});

--- a/components/example-card.tsx
+++ b/components/example-card.tsx
@@ -1,0 +1,110 @@
+import { colors } from "@/constants/colors";
+import { useRef, useState } from "react";
+import { Animated, Pressable, StyleSheet, Text, View } from "react-native";
+
+type ExampleCardProps = {
+    sentence: string;
+    keyword: string;
+    translation: string;
+}
+
+const ExampleCard = ({ sentence, keyword, translation }: ExampleCardProps) => {
+    const [showBack, setShowBack] = useState(false);
+    const scaleX = useRef(new Animated.Value(1)).current;
+
+    const handleFlip = () => {
+        Animated.timing(scaleX, {
+            toValue: 0,
+            duration: 150,
+            useNativeDriver: true,
+        }).start(() => {
+            setShowBack(prev => !prev);
+            Animated.timing(scaleX, {
+                toValue: 1,
+                duration: 150,
+                useNativeDriver: true,
+            }).start();
+        });
+    };
+
+    const renderSentence = () => {
+        const parts = sentence.split(new RegExp(`(${keyword})`, 'i'));
+        return (
+            <Text style={styles.sentence}>
+                {parts.map((part, index) =>
+                    part.toLowerCase() === keyword.toLowerCase() ? (
+                        <Text key={index} style={styles.highlight}>{part}</Text>
+                    ) : (
+                        <Text key={index}>{part}</Text>
+                    )
+                )}
+            </Text>
+        );
+    };
+
+    return (
+        <Pressable onPress={handleFlip} style={styles.wrapper}>
+            <Animated.View style={[
+                styles.container,
+                showBack && styles.backContainer,
+                { transform: [{ scaleX }] }
+            ]}>
+                {showBack ? (
+                    <View style={styles.backContent}>
+                        <Text style={styles.translation}>{translation}</Text>
+                    </View>
+                ) : (
+                    <View style={styles.frontContent}>
+                        {renderSentence()}
+                    </View>
+                )}
+            </Animated.View>
+        </Pressable>
+    );
+};
+
+const styles = StyleSheet.create({
+    wrapper: {
+        width: '100%',
+        minHeight: 187,
+    },
+    container: {
+        width: '100%',
+        minHeight: 187,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: '#fff',
+        boxShadow: '0 4px 7.2px 0 rgba(0, 0, 0, 0.08)',
+        borderRadius: 20,
+        padding: 24,
+    },
+    backContainer: {
+        backgroundColor: colors.primary[500],
+    },
+    frontContent: {
+        alignItems: 'center',
+    },
+    backContent: {
+        alignItems: 'center',
+    },
+    sentence: {
+        fontSize: 22,
+        fontWeight: '600',
+        color: colors.grayscale[900],
+        textAlign: 'center',
+        lineHeight: 34,
+    },
+    highlight: {
+        color: colors.primary[500],
+        fontWeight: 'bold',
+    },
+    translation: {
+        fontSize: 22,
+        fontWeight: '700',
+        color: '#fff',
+        textAlign: 'center',
+        lineHeight: 34,
+    },
+});
+
+export default ExampleCard;

--- a/components/learning/LearningCompleteScreen.tsx
+++ b/components/learning/LearningCompleteScreen.tsx
@@ -9,6 +9,7 @@ type LearningCompleteScreenProps = {
   headerTitle?: string;
   title: string;
   wordsLearned: number;
+  learnedLabel?: string;
   xpEarned: number;
   buttonTitle?: string;
   onButtonPress: () => void;
@@ -18,6 +19,7 @@ export default function LearningCompleteScreen({
   headerTitle = '학습 완료',
   title,
   wordsLearned,
+  learnedLabel = '오늘배운\n단어',
   xpEarned,
   buttonTitle = '계속하기',
   onButtonPress,
@@ -43,7 +45,7 @@ export default function LearningCompleteScreen({
           <View style={styles.statsRow}>
             <View style={styles.statItem}>
               <Text style={styles.statNumber}>{wordsLearned}</Text>
-              <Text style={styles.statLabel}>{'오늘배운\n단어'}</Text>
+              <Text style={styles.statLabel}>{learnedLabel}</Text>
             </View>
             <View style={styles.statItem}>
               <Text style={styles.statNumber}>{xpEarned}</Text>

--- a/components/navigation/CommonStackScreen.tsx
+++ b/components/navigation/CommonStackScreen.tsx
@@ -17,6 +17,7 @@ export default function CommonStackScreen({
   return (
     <Stack.Screen
       options={{
+        headerShown: true,
         headerShadowVisible: false,
         headerStyle: {
           backgroundColor,


### PR DESCRIPTION
## 📝 작업 내용
- 학습 탭에서 예문 학습 카드 선택 시 예문 학습 화면으로 이동하도록 연결
- 예문 학습 화면에 플래시 카드 화면과 동일한 상단 헤더 적용
---

## 🔄 변경 사항
- `ProgressCard`에 `/example-sentence` 라우팅 추가
- `example-sentence` 화면을 루트 Stack에 등록
- `CommonStackScreen`에서 헤더 표시 옵션 명시
- `LearningCompleteScreen`에 완료 결과 라벨을 커스텀할 수 있는 `learnedLabel` prop 추가
- 예문 학습 완료 화면에서 `오늘배운\n예문` 라벨 전달

---

## 🔗 관련 이슈
#9 