### PR TITLE
feat: 마이페이지 제작

### DIFF
--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -1,15 +1,132 @@
-import { StyleSheet, View } from 'react-native';
+import SeedIcon from '@/assets/images/seed.svg';
+import LevelCard from '@/components/level-card';
+import MypageCalendar from '@/components/mypage/mypage-calendar';
+import MyPageSection from '@/components/mypage/mypage-section';
+import { colors } from '@/constants/colors';
+import { router } from 'expo-router';
+import { Alert, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+// 투두 완료 단계 더미 데이터 (0: 없음, 1~3: 단계별)
+const completionData: Record<string, 0 | 1 | 2 | 3> = {
+  '2026-05-01': 1,
+  '2026-05-02': 3,
+  '2026-05-05': 2,
+  '2026-05-06': 3,
+  '2026-05-07': 1,
+  '2026-05-08': 3,
+  '2026-05-09': 2,
+  '2026-05-12': 1,
+  '2026-05-13': 2,
+};
+
+const pastCharacters = [
+  { id: '1', name: '씽씽이' },
+  { id: '2', name: '씽씽이' },
+  { id: '3', name: '씽씽이' },
+];
+
 export default function MypageScreen() {
   return (
-    <View style={styles.container}>
-    </View>
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={styles.pageTitle}>마이페이지</Text>
+        <Text style={styles.greeting}>선이님, 안녕하세요 !</Text>
+
+        <MyPageSection title="현재 레벨" noCard style={styles.section}>
+          <LevelCard
+            level={1}
+            characterName="씨앗"
+            currentXP={45}
+            maxXP={100}
+            CharacterSvg={SeedIcon}
+            onPress={() => router.push('/(tabs)/home')}
+          />
+        </MyPageSection>
+
+        <MyPageSection title="나의 연속학습" style={styles.section}>
+          <MypageCalendar completionData={completionData} />
+        </MyPageSection>
+
+        <MyPageSection title="역대 Avocado" style={styles.section}>
+          <View style={styles.characterGrid}>
+            {pastCharacters.map(char => (
+              <View key={char.id} style={styles.characterItem}>
+                <SeedIcon width={80} height={80} />
+                <Text style={styles.characterName}>{char.name}</Text>
+              </View>
+            ))}
+          </View>
+        </MyPageSection>
+
+        <View style={styles.bottomButtons}>
+          <TouchableOpacity onPress={() => Alert.alert('로그아웃')}>
+            <Text style={styles.bottomButtonText}>로그아웃</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => Alert.alert('탈퇴하기')}>
+            <Text style={styles.bottomButtonText}>탈퇴하기</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
-    gap: 10
+    backgroundColor: '#EFFCFF',
+  },
+  scrollContent: {
+    paddingHorizontal: 24,
+    paddingBottom: 40,
+  },
+  pageTitle: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: colors.grayscale[900],
+    fontFamily: 'Pretendard',
+    marginTop: 8,
+  },
+  greeting: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: colors.grayscale[800],
+    fontFamily: 'Pretendard',
+    marginTop: 20,
+    marginBottom: 8,
+  },
+  section: {
+    marginTop: 24,
+  },
+  characterGrid: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    paddingVertical: 8,
+  },
+  characterItem: {
+    alignItems: 'center',
+    gap: 8,
+  },
+  characterName: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: colors.grayscale[700],
+    fontFamily: 'Pretendard',
+  },
+  bottomButtons: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 40,
+    marginTop: 40,
+  },
+  bottomButtonText: {
+    fontSize: 15,
+    color: colors.grayscale[400],
+    fontFamily: 'Pretendard',
+    fontWeight: '500',
   },
 });

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -7,7 +7,6 @@ import { router } from 'expo-router';
 import { Alert, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-// 투두 완료 단계 더미 데이터 (0: 없음, 1~3: 단계별)
 const completionData: Record<string, 0 | 1 | 2 | 3> = {
   '2026-05-01': 1,
   '2026-05-02': 3,
@@ -29,12 +28,19 @@ const pastCharacters = [
 export default function MypageScreen() {
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={[styles.cloud, styles.topCloud]} />
+      <View style={[styles.cloud, styles.rightCloud]} />
+
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
       >
         <Text style={styles.pageTitle}>마이페이지</Text>
-        <Text style={styles.greeting}>선이님, 안녕하세요 !</Text>
+
+        <View style={styles.greetingCard}>
+          <Text style={styles.greetingName}>셔니님</Text>
+          <Text style={styles.greetingText}>안녕하세요 !</Text>
+        </View>
 
         <MyPageSection title="현재 레벨" noCard style={styles.section}>
           <LevelCard
@@ -55,7 +61,9 @@ export default function MypageScreen() {
           <View style={styles.characterGrid}>
             {pastCharacters.map(char => (
               <View key={char.id} style={styles.characterItem}>
-                <SeedIcon width={80} height={80} />
+                <View style={styles.characterBubble}>
+                  <SeedIcon width={72} height={72} />
+                </View>
                 <Text style={styles.characterName}>{char.name}</Text>
               </View>
             ))}
@@ -66,6 +74,7 @@ export default function MypageScreen() {
           <TouchableOpacity onPress={() => Alert.alert('로그아웃')}>
             <Text style={styles.bottomButtonText}>로그아웃</Text>
           </TouchableOpacity>
+          <View style={styles.divider} />
           <TouchableOpacity onPress={() => Alert.alert('탈퇴하기')}>
             <Text style={styles.bottomButtonText}>탈퇴하기</Text>
           </TouchableOpacity>
@@ -80,6 +89,25 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#EFFCFF',
   },
+  cloud: {
+    position: 'absolute',
+    backgroundColor: '#FFF',
+  },
+  topCloud: {
+    top: -40,
+    left: -34,
+    width: 150,
+    height: 128,
+    borderBottomRightRadius: 64,
+  },
+  rightCloud: {
+    top: 180,
+    right: -44,
+    width: 120,
+    height: 80,
+    borderTopLeftRadius: 48,
+    borderBottomLeftRadius: 48,
+  },
   scrollContent: {
     paddingHorizontal: 24,
     paddingBottom: 40,
@@ -91,13 +119,23 @@ const styles = StyleSheet.create({
     fontFamily: 'Pretendard',
     marginTop: 8,
   },
-  greeting: {
+  greetingCard: {
+    marginTop: 16,
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 6,
+  },
+  greetingName: {
     fontSize: 18,
-    fontWeight: '600',
-    color: colors.grayscale[800],
+    fontWeight: '700',
+    color: colors.primary[500],
     fontFamily: 'Pretendard',
-    marginTop: 20,
-    marginBottom: 8,
+  },
+  greetingText: {
+    fontSize: 17,
+    fontWeight: '600',
+    color: colors.grayscale[700],
+    fontFamily: 'Pretendard',
   },
   section: {
     marginTop: 24,
@@ -109,7 +147,15 @@ const styles = StyleSheet.create({
   },
   characterItem: {
     alignItems: 'center',
-    gap: 8,
+    gap: 10,
+  },
+  characterBubble: {
+    width: 96,
+    height: 96,
+    borderRadius: 48,
+    backgroundColor: colors.primary[50],
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   characterName: {
     fontSize: 14,
@@ -120,8 +166,14 @@ const styles = StyleSheet.create({
   bottomButtons: {
     flexDirection: 'row',
     justifyContent: 'center',
-    gap: 40,
+    alignItems: 'center',
+    gap: 20,
     marginTop: 40,
+  },
+  divider: {
+    width: 1,
+    height: 14,
+    backgroundColor: colors.grayscale[300],
   },
   bottomButtonText: {
     fontSize: 15,

--- a/components/mypage/mypage-calendar.tsx
+++ b/components/mypage/mypage-calendar.tsx
@@ -1,0 +1,157 @@
+import { colors } from '@/constants/colors';
+import { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+type DayCompletion = 0 | 1 | 2 | 3;
+
+type MypageCalendarProps = {
+  completionData?: Record<string, DayCompletion>;
+};
+
+const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
+
+const COMPLETION_BG: Record<DayCompletion, string | undefined> = {
+  0: undefined,
+  1: colors.primary[100],
+  2: colors.primary[300],
+  3: colors.primary[500],
+};
+
+const MypageCalendar = ({ completionData = {} }: MypageCalendarProps) => {
+  const today = new Date();
+  const [year, setYear] = useState(today.getFullYear());
+  const [month, setMonth] = useState(today.getMonth() + 1);
+
+  const handlePrev = () => {
+    if (month === 1) { setYear(y => y - 1); setMonth(12); }
+    else setMonth(m => m - 1);
+  };
+
+  const handleNext = () => {
+    if (month === 12) { setYear(y => y + 1); setMonth(1); }
+    else setMonth(m => m + 1);
+  };
+
+  const firstDay = new Date(year, month - 1, 1).getDay();
+  const lastDate = new Date(year, month, 0).getDate();
+  const prevMonthLastDate = new Date(year, month - 1, 0).getDate();
+
+  const cells: { day: number; isCurrentMonth: boolean; dateKey: string }[] = [];
+
+  for (let i = firstDay - 1; i >= 0; i--) {
+    const d = prevMonthLastDate - i;
+    const pm = month === 1 ? 12 : month - 1;
+    const py = month === 1 ? year - 1 : year;
+    cells.push({ day: d, isCurrentMonth: false, dateKey: `${py}-${String(pm).padStart(2, '0')}-${String(d).padStart(2, '0')}` });
+  }
+
+  for (let d = 1; d <= lastDate; d++) {
+    cells.push({ day: d, isCurrentMonth: true, dateKey: `${year}-${String(month).padStart(2, '0')}-${String(d).padStart(2, '0')}` });
+  }
+
+  const remaining = 42 - cells.length;
+  for (let d = 1; d <= remaining; d++) {
+    const nm = month === 12 ? 1 : month + 1;
+    const ny = month === 12 ? year + 1 : year;
+    cells.push({ day: d, isCurrentMonth: false, dateKey: `${ny}-${String(nm).padStart(2, '0')}-${String(d).padStart(2, '0')}` });
+  }
+
+  return (
+    <View>
+      <View style={styles.header}>
+        <Pressable onPress={handlePrev} hitSlop={8} style={styles.navButton}>
+          <Text style={styles.navText}>{'<'}</Text>
+        </Pressable>
+        <Text style={styles.monthTitle}>{year}년 {month}월</Text>
+        <Pressable onPress={handleNext} hitSlop={8} style={styles.navButton}>
+          <Text style={styles.navText}>{'>'}</Text>
+        </Pressable>
+      </View>
+
+      <View style={styles.row}>
+        {DAY_LABELS.map(label => (
+          <View key={label} style={styles.cell}>
+            <Text style={styles.dayLabel}>{label}</Text>
+          </View>
+        ))}
+      </View>
+
+      {Array.from({ length: 6 }, (_, row) => (
+        <View key={row} style={styles.row}>
+          {cells.slice(row * 7, row * 7 + 7).map((cell, col) => {
+            const completion = (completionData[cell.dateKey] ?? 0) as DayCompletion;
+            const bg = COMPLETION_BG[completion];
+            const textColor = completion > 0
+              ? '#fff'
+              : cell.isCurrentMonth
+              ? colors.grayscale[700]
+              : colors.grayscale[300];
+
+            return (
+              <View key={col} style={styles.cell}>
+                <View style={[styles.dayCircle, bg ? { backgroundColor: bg } : undefined]}>
+                  <Text style={[styles.dayText, { color: textColor }]}>{cell.day}</Text>
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 12,
+    gap: 16,
+  },
+  navButton: {
+    padding: 4,
+  },
+  navText: {
+    fontSize: 16,
+    color: colors.grayscale[600],
+    fontFamily: 'Pretendard',
+    fontWeight: '600',
+  },
+  monthTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.grayscale[800],
+    fontFamily: 'Pretendard',
+    minWidth: 100,
+    textAlign: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  cell: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  dayLabel: {
+    fontSize: 13,
+    color: colors.grayscale[400],
+    fontFamily: 'Pretendard',
+    fontWeight: '500',
+  },
+  dayCircle: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dayText: {
+    fontSize: 13,
+    fontFamily: 'Pretendard',
+    fontWeight: '500',
+  },
+});
+
+export default MypageCalendar;

--- a/components/mypage/mypage-calendar.tsx
+++ b/components/mypage/mypage-calendar.tsx
@@ -17,8 +17,19 @@ const COMPLETION_BG: Record<DayCompletion, string | undefined> = {
   3: colors.primary[500],
 };
 
+const LEGEND_STEPS: { label: string; color: string }[] = [
+  { label: '1단계', color: colors.primary[100] },
+  { label: '2단계', color: colors.primary[300] },
+  { label: '3단계', color: colors.primary[500] },
+];
+
+const toDateKey = (y: number, m: number, d: number) =>
+  `${y}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+
 const MypageCalendar = ({ completionData = {} }: MypageCalendarProps) => {
   const today = new Date();
+  const todayKey = toDateKey(today.getFullYear(), today.getMonth() + 1, today.getDate());
+
   const [year, setYear] = useState(today.getFullYear());
   const [month, setMonth] = useState(today.getMonth() + 1);
 
@@ -42,18 +53,18 @@ const MypageCalendar = ({ completionData = {} }: MypageCalendarProps) => {
     const d = prevMonthLastDate - i;
     const pm = month === 1 ? 12 : month - 1;
     const py = month === 1 ? year - 1 : year;
-    cells.push({ day: d, isCurrentMonth: false, dateKey: `${py}-${String(pm).padStart(2, '0')}-${String(d).padStart(2, '0')}` });
+    cells.push({ day: d, isCurrentMonth: false, dateKey: toDateKey(py, pm, d) });
   }
 
   for (let d = 1; d <= lastDate; d++) {
-    cells.push({ day: d, isCurrentMonth: true, dateKey: `${year}-${String(month).padStart(2, '0')}-${String(d).padStart(2, '0')}` });
+    cells.push({ day: d, isCurrentMonth: true, dateKey: toDateKey(year, month, d) });
   }
 
   const remaining = 42 - cells.length;
   for (let d = 1; d <= remaining; d++) {
     const nm = month === 12 ? 1 : month + 1;
     const ny = month === 12 ? year + 1 : year;
-    cells.push({ day: d, isCurrentMonth: false, dateKey: `${ny}-${String(nm).padStart(2, '0')}-${String(d).padStart(2, '0')}` });
+    cells.push({ day: d, isCurrentMonth: false, dateKey: toDateKey(ny, nm, d) });
   }
 
   return (
@@ -69,9 +80,15 @@ const MypageCalendar = ({ completionData = {} }: MypageCalendarProps) => {
       </View>
 
       <View style={styles.row}>
-        {DAY_LABELS.map(label => (
+        {DAY_LABELS.map((label, idx) => (
           <View key={label} style={styles.cell}>
-            <Text style={styles.dayLabel}>{label}</Text>
+            <Text style={[
+              styles.dayLabel,
+              idx === 0 && styles.sundayLabel,
+              idx === 6 && styles.saturdayLabel,
+            ]}>
+              {label}
+            </Text>
           </View>
         ))}
       </View>
@@ -81,6 +98,8 @@ const MypageCalendar = ({ completionData = {} }: MypageCalendarProps) => {
           {cells.slice(row * 7, row * 7 + 7).map((cell, col) => {
             const completion = (completionData[cell.dateKey] ?? 0) as DayCompletion;
             const bg = COMPLETION_BG[completion];
+            const isToday = cell.dateKey === todayKey;
+
             const textColor = completion > 0
               ? '#fff'
               : cell.isCurrentMonth
@@ -89,7 +108,11 @@ const MypageCalendar = ({ completionData = {} }: MypageCalendarProps) => {
 
             return (
               <View key={col} style={styles.cell}>
-                <View style={[styles.dayCircle, bg ? { backgroundColor: bg } : undefined]}>
+                <View style={[
+                  styles.dayCircle,
+                  bg ? { backgroundColor: bg } : undefined,
+                  isToday && !bg ? styles.todayBorder : undefined,
+                ]}>
                   <Text style={[styles.dayText, { color: textColor }]}>{cell.day}</Text>
                 </View>
               </View>
@@ -97,6 +120,15 @@ const MypageCalendar = ({ completionData = {} }: MypageCalendarProps) => {
           })}
         </View>
       ))}
+
+      <View style={styles.legend}>
+        {LEGEND_STEPS.map(step => (
+          <View key={step.label} style={styles.legendItem}>
+            <View style={[styles.legendDot, { backgroundColor: step.color }]} />
+            <Text style={styles.legendText}>{step.label}</Text>
+          </View>
+        ))}
+      </View>
     </View>
   );
 };
@@ -140,6 +172,12 @@ const styles = StyleSheet.create({
     fontFamily: 'Pretendard',
     fontWeight: '500',
   },
+  sundayLabel: {
+    color: '#F87171',
+  },
+  saturdayLabel: {
+    color: '#60A5FA',
+  },
   dayCircle: {
     width: 32,
     height: 32,
@@ -147,8 +185,37 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  todayBorder: {
+    borderWidth: 1.5,
+    borderColor: colors.primary[400],
+  },
   dayText: {
     fontSize: 13,
+    fontFamily: 'Pretendard',
+    fontWeight: '500',
+  },
+  legend: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 16,
+    marginTop: 14,
+    paddingTop: 12,
+    borderTopWidth: 1,
+    borderTopColor: colors.grayscale[100],
+  },
+  legendItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+  },
+  legendDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+  },
+  legendText: {
+    fontSize: 12,
+    color: colors.grayscale[400],
     fontFamily: 'Pretendard',
     fontWeight: '500',
   },

--- a/components/mypage/mypage-section.tsx
+++ b/components/mypage/mypage-section.tsx
@@ -1,0 +1,38 @@
+import { colors } from '@/constants/colors';
+import { StyleSheet, Text, View, ViewStyle } from 'react-native';
+
+type MyPageSectionProps = {
+  title: string;
+  children: React.ReactNode;
+  style?: ViewStyle;
+  noCard?: boolean;
+};
+
+const MyPageSection = ({ title, children, style, noCard }: MyPageSectionProps) => {
+  return (
+    <View style={[styles.wrapper, style]}>
+      <Text style={styles.title}>{title}</Text>
+      {noCard ? children : <View style={styles.card}>{children}</View>}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    gap: 10,
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: colors.grayscale[800],
+    fontFamily: 'Pretendard',
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 20,
+    padding: 16,
+    boxShadow: '0 0 9px 0 rgba(0, 0, 0, 0.07)',
+  },
+});
+
+export default MyPageSection;


### PR DESCRIPTION
## 📝 작업 내용
- 마이페이지 화면을 구현했습니다.
- 마이페이지 디자인을 리팩토링하고 연속학습 캘린더 UI를 개선했습니다.

---

## 🔄 변경 사항
- 마이페이지 탭 화면 추가
- 현재 레벨, 나의 연속학습, 역대 Avocado 섹션 구성
- `LevelCard`, `MypageCalendar`, `MyPageSection` 컴포넌트 연동
- 로그아웃 / 탈퇴하기 버튼 추가
- 연속학습 캘린더 월 이동 기능 추가
- 학습 완료 단계별 날짜 표시 적용
- 마이페이지 배경 구름 장식 및 인사말 영역 스타일 개선
- 역대 Avocado 캐릭터 영역에 원형 배경 스타일 적용
- 캘린더 오늘 날짜 표시, 주말 라벨 색상, 단계별 범례 추가
- 날짜 key 생성 로직을 `toDateKey` 함수로 분리

---

## 🔗 관련 이슈
Closes #12