### PR TITLE
feat: 온보딩 스크린 제작

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,19 +2,16 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
-import { useColorScheme } from '@/hooks/use-color-scheme';
-
 export const unstable_settings = {
   initialRouteName: 'login',
 };
 
 export default function RootLayout() {
-  const colorScheme = useColorScheme();
-
   return (
     <>
        <Stack>
           <Stack.Screen name="login" options={{ headerShown: false }} />
+          <Stack.Screen name="onboarding" options={{ headerShown: false, animation: 'fade' }} />
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="flash-card" options={{ headerShown: false }} />
           <Stack.Screen name="example-sentence" options={{ headerShown: false }} />

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -11,7 +11,7 @@ export default function LoginScreen() {
     Alert.alert('네이버 로그인', '네이버 로그인 연동 예정', [
       {
         text: '확인',
-        onPress: () => router.replace('/(tabs)/study'),
+        onPress: () => router.replace({ pathname: '/onboarding' } as any),
       },
     ]);
   };
@@ -21,7 +21,7 @@ export default function LoginScreen() {
     Alert.alert('카카오 로그인', '카카오 로그인 연동 예정', [
       {
         text: '확인',
-        onPress: () => router.replace('/(tabs)/study'),
+        onPress: () => router.replace({ pathname: '/onboarding' } as any),
       },
     ]);
   };

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,0 +1,83 @@
+import { LinearGradient } from 'expo-linear-gradient';
+import { router } from 'expo-router';
+import { useState } from 'react';
+import { KeyboardAvoidingView, Platform, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import OnboardingFooter from '@/components/onboarding/OnboardingFooter';
+import OnboardingStepContent from '@/components/onboarding/OnboardingStepContent';
+import StepIndicator from '@/components/onboarding/StepIndicator';
+import { TOTAL_ONBOARDING_STEPS } from '@/components/onboarding/onboarding-data';
+import { useOnboardingAnimations } from '@/components/onboarding/useOnboardingAnimations';
+
+export default function OnboardingScreen() {
+  const [step, setStep] = useState(0);
+  const [characterName, setCharacterName] = useState('');
+  const [selectedLevel, setSelectedLevel] = useState<string | null>(null);
+  const animations = useOnboardingAnimations(step);
+
+  const handleNext = () => {
+    if (step < TOTAL_ONBOARDING_STEPS - 1) {
+      animations.goToStep(step + 1, setStep);
+    } else {
+      router.replace('/(tabs)/study');
+    }
+  };
+
+  const handleBack = () => {
+    if (step > 0) {
+      animations.goToStep(step - 1, setStep);
+    }
+  };
+
+  const handleSelectLevel = (id: string, index: number) => {
+    setSelectedLevel(id);
+    animations.animateLevelSelect(index);
+  };
+
+  const isNextDisabled =
+    (step === 0 && characterName.trim() === '') || (step === 3 && selectedLevel === null);
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <LinearGradient colors={['#D8F5E6', '#F0FDF5']} style={StyleSheet.absoluteFill} />
+
+      <KeyboardAvoidingView
+        style={styles.container}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <StepIndicator currentStep={step} totalSteps={TOTAL_ONBOARDING_STEPS} />
+        <OnboardingStepContent
+          step={step}
+          characterName={characterName}
+          selectedLevel={selectedLevel}
+          fadeAnim={animations.fadeAnim}
+          slideAnim={animations.slideAnim}
+          floatAnim={animations.floatAnim}
+          pillAnims={animations.pillAnims}
+          cashAnims={animations.cashAnims}
+          levelAnims={animations.levelAnims}
+          levelScales={animations.levelScales}
+          onChangeCharacterName={setCharacterName}
+          onSelectLevel={handleSelectLevel}
+        />
+        <OnboardingFooter
+          step={step}
+          isNextDisabled={isNextDisabled}
+          onBack={handleBack}
+          onNext={handleNext}
+        />
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: 24,
+  },
+});

--- a/components/onboarding/LevelList.tsx
+++ b/components/onboarding/LevelList.tsx
@@ -1,0 +1,109 @@
+import { MaterialIcons } from '@expo/vector-icons';
+import { Animated, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { colors } from '@/constants/colors';
+
+import { LEVELS } from './onboarding-data';
+
+interface LevelListProps {
+  selectedLevel: string | null;
+  levelAnims: Animated.Value[];
+  levelScales: Animated.Value[];
+  onSelectLevel: (id: string, index: number) => void;
+}
+
+export default function LevelList({
+  selectedLevel,
+  levelAnims,
+  levelScales,
+  onSelectLevel,
+}: LevelListProps) {
+  return (
+    <View style={styles.levelsWrapper}>
+      {LEVELS.map((level, index) => {
+        const isSelected = selectedLevel === level.id;
+
+        return (
+          <Animated.View
+            key={level.id}
+            style={{
+              opacity: levelAnims[index],
+              transform: [
+                {
+                  translateX: levelAnims[index].interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [32, 0],
+                  }),
+                },
+                { scale: levelScales[index] },
+              ],
+            }}
+          >
+            <Pressable
+              style={[styles.levelItem, isSelected && styles.levelItemSelected]}
+              onPress={() => onSelectLevel(level.id, index)}
+            >
+              <View style={styles.levelText}>
+                <Text style={[styles.levelTitle, isSelected && styles.levelTitleSelected]}>
+                  {level.title}
+                </Text>
+                <Text
+                  style={[styles.levelDescription, isSelected && styles.levelDescriptionSelected]}
+                >
+                  {level.description}
+                </Text>
+              </View>
+              <MaterialIcons
+                name="chevron-right"
+                size={22}
+                color={isSelected ? colors.primary[600] : colors.grayscale[400]}
+              />
+            </Pressable>
+          </Animated.View>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  levelsWrapper: {
+    flex: 1,
+    width: '100%',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  levelItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: 'rgba(255,255,255,0.8)',
+    borderRadius: 16,
+    paddingVertical: 18,
+    paddingHorizontal: 20,
+    borderWidth: 1.5,
+    borderColor: 'transparent',
+  },
+  levelItemSelected: {
+    backgroundColor: colors.primary[50],
+    borderColor: colors.primary[400],
+  },
+  levelText: {
+    gap: 4,
+  },
+  levelTitle: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: colors.grayscale[800],
+  },
+  levelTitleSelected: {
+    color: colors.primary[700],
+  },
+  levelDescription: {
+    fontSize: 13,
+    color: colors.grayscale[500],
+  },
+  levelDescriptionSelected: {
+    color: colors.primary[600],
+  },
+});

--- a/components/onboarding/OnboardingFooter.tsx
+++ b/components/onboarding/OnboardingFooter.tsx
@@ -1,0 +1,61 @@
+import { StyleSheet, View } from 'react-native';
+
+import Button from '@/components/buttons/Button';
+
+import { TOTAL_ONBOARDING_STEPS } from './onboarding-data';
+
+interface OnboardingFooterProps {
+  step: number;
+  isNextDisabled: boolean;
+  onBack: () => void;
+  onNext: () => void;
+}
+
+export default function OnboardingFooter({
+  step,
+  isNextDisabled,
+  onBack,
+  onNext,
+}: OnboardingFooterProps) {
+  return (
+    <View style={styles.buttonsArea}>
+      {step === 0 ? (
+        <Button
+          title="다음으로"
+          onPress={onNext}
+          variant={isNextDisabled ? 'disabled' : 'primary'}
+        />
+      ) : (
+        <View style={styles.navRow}>
+          <View style={styles.backBtn}>
+            <Button title="이전" onPress={onBack} variant="secondary" />
+          </View>
+          <View style={styles.nextBtn}>
+            <Button
+              title={step === TOTAL_ONBOARDING_STEPS - 1 ? '시작하기' : '다음으로'}
+              onPress={onNext}
+              variant={isNextDisabled ? 'disabled' : 'primary'}
+            />
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  buttonsArea: {
+    paddingBottom: 28,
+    paddingTop: 12,
+  },
+  navRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  backBtn: {
+    flex: 1,
+  },
+  nextBtn: {
+    flex: 2,
+  },
+});

--- a/components/onboarding/OnboardingStepContent.tsx
+++ b/components/onboarding/OnboardingStepContent.tsx
@@ -1,0 +1,93 @@
+import { Animated, StyleSheet, Text } from 'react-native';
+
+import { colors } from '@/constants/colors';
+
+import { ONBOARDING_STEP_META } from './onboarding-data';
+import CashStep from './steps/CashStep';
+import CharacterNameStep from './steps/CharacterNameStep';
+import GrowthStep from './steps/GrowthStep';
+import LevelStep from './steps/LevelStep';
+
+interface OnboardingStepContentProps {
+  step: number;
+  characterName: string;
+  selectedLevel: string | null;
+  fadeAnim: Animated.Value;
+  slideAnim: Animated.Value;
+  floatAnim: Animated.Value;
+  pillAnims: Animated.Value[];
+  cashAnims: Animated.Value[];
+  levelAnims: Animated.Value[];
+  levelScales: Animated.Value[];
+  onChangeCharacterName: (name: string) => void;
+  onSelectLevel: (id: string, index: number) => void;
+}
+
+export default function OnboardingStepContent({
+  step,
+  characterName,
+  selectedLevel,
+  fadeAnim,
+  slideAnim,
+  floatAnim,
+  pillAnims,
+  cashAnims,
+  levelAnims,
+  levelScales,
+  onChangeCharacterName,
+  onSelectLevel,
+}: OnboardingStepContentProps) {
+  const { title, subtitle } = ONBOARDING_STEP_META[step];
+
+  return (
+    <Animated.View
+      style={[styles.content, { opacity: fadeAnim, transform: [{ translateY: slideAnim }] }]}
+    >
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.subtitle}>{subtitle}</Text>
+
+      {step === 0 && (
+        <CharacterNameStep
+          characterName={characterName}
+          floatAnim={floatAnim}
+          onChangeCharacterName={onChangeCharacterName}
+        />
+      )}
+
+      {step === 1 && <GrowthStep pillAnims={pillAnims} />}
+
+      {step === 2 && <CashStep cashAnims={cashAnims} />}
+
+      {step === 3 && (
+        <LevelStep
+          selectedLevel={selectedLevel}
+          levelAnims={levelAnims}
+          levelScales={levelScales}
+          onSelectLevel={onSelectLevel}
+        />
+      )}
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    paddingTop: 40,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: colors.grayscale[900],
+    textAlign: 'center',
+    marginBottom: 10,
+    letterSpacing: -0.3,
+  },
+  subtitle: {
+    fontSize: 15,
+    color: colors.grayscale[500],
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+});

--- a/components/onboarding/StepIndicator.tsx
+++ b/components/onboarding/StepIndicator.tsx
@@ -1,0 +1,49 @@
+import { StyleSheet, View } from 'react-native';
+
+import { colors } from '@/constants/colors';
+
+interface StepIndicatorProps {
+  currentStep: number;
+  totalSteps: number;
+}
+
+export default function StepIndicator({ currentStep, totalSteps }: StepIndicatorProps) {
+  return (
+    <View style={styles.dotsRow}>
+      {Array.from({ length: totalSteps }).map((_, index) => (
+        <View
+          key={index}
+          style={[
+            styles.dot,
+            index === currentStep && styles.dotActive,
+            index < currentStep && styles.dotPast,
+          ]}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  dotsRow: {
+    flexDirection: 'row',
+    gap: 6,
+    alignSelf: 'center',
+    marginTop: 20,
+    marginBottom: 8,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: colors.grayscale[300],
+  },
+  dotActive: {
+    width: 20,
+    backgroundColor: colors.primary[500],
+    borderRadius: 4,
+  },
+  dotPast: {
+    backgroundColor: colors.primary[300],
+  },
+});

--- a/components/onboarding/onboarding-data.ts
+++ b/components/onboarding/onboarding-data.ts
@@ -1,0 +1,19 @@
+export const TOTAL_ONBOARDING_STEPS = 4;
+
+export const ONBOARDING_STEP_META = [
+  { title: '반가워요!', subtitle: '오늘부터 함께할 친구의 이름을 지어주세요' },
+  { title: '같이 성장해요', subtitle: '학습할 수록 나의 캐릭터는 성장해요' },
+  {
+    title: '캐시를 보아보세요',
+    subtitle: '상점에서 필요한 물건을 구매해 보세요,\n캐릭터는 더 빨리 성장합니다',
+  },
+  { title: '어디서부터 시작할까요?', subtitle: '나의 레벨을 선택하고 성장해요' },
+];
+
+export const GROWTH_PILLS = ['학습 완료', 'XP 지급', '캐릭터 성장'];
+
+export const LEVELS = [
+  { id: 'beginner', title: '초급', description: '처음부터 시작 해볼래요' },
+  { id: 'intermediate', title: '중급', description: '기초는 알지만 응용에서 말해볼래요' },
+  { id: 'advanced', title: '고급', description: '원어민처럼 이야기할래요' },
+];

--- a/components/onboarding/steps/CashStep.tsx
+++ b/components/onboarding/steps/CashStep.tsx
@@ -1,0 +1,66 @@
+import { Animated, StyleSheet, View } from 'react-native';
+
+import CashIcon from '@/assets/images/cash.svg';
+import StoreIcon from '@/assets/images/store.svg';
+
+interface CashStepProps {
+  cashAnims: Animated.Value[];
+}
+
+export default function CashStep({ cashAnims }: CashStepProps) {
+  return (
+    <View style={styles.cashWrapper}>
+      <View style={styles.cashCoinsRow}>
+        {[70, 90, 70].map((size, index) => (
+          <Animated.View
+            key={index}
+            style={[
+              styles.cashIconItem,
+              index === 1 && styles.cashIconCenter,
+              {
+                opacity: cashAnims[index],
+                transform: [
+                  {
+                    scale: cashAnims[index].interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [0.4, 1],
+                    }),
+                  },
+                  {
+                    translateY: cashAnims[index].interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [30, 0],
+                    }),
+                  },
+                ],
+              },
+            ]}
+          >
+            <CashIcon width={size} height={size} />
+          </Animated.View>
+        ))}
+      </View>
+      <Animated.View style={{ opacity: cashAnims[2], marginTop: 8 }}>
+        <StoreIcon width={110} height={90} />
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  cashWrapper: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+  },
+  cashCoinsRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 8,
+  },
+  cashIconItem: {},
+  cashIconCenter: {
+    marginBottom: 10,
+  },
+});

--- a/components/onboarding/steps/CharacterNameStep.tsx
+++ b/components/onboarding/steps/CharacterNameStep.tsx
@@ -1,0 +1,44 @@
+import { Animated, StyleSheet, View } from 'react-native';
+
+import SeedIcon from '@/assets/images/seed.svg';
+import Input from '@/components/input/Input';
+
+interface CharacterNameStepProps {
+  characterName: string;
+  floatAnim: Animated.Value;
+  onChangeCharacterName: (name: string) => void;
+}
+
+export default function CharacterNameStep({
+  characterName,
+  floatAnim,
+  onChangeCharacterName,
+}: CharacterNameStepProps) {
+  return (
+    <View style={styles.step}>
+      <Animated.View style={{ transform: [{ translateY: floatAnim }] }}>
+        <SeedIcon width={220} height={214} />
+      </Animated.View>
+      <View style={styles.inputWrapper}>
+        <Input
+          placeholder="이름을 지어주세요!"
+          value={characterName}
+          onChangeText={onChangeCharacterName}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  step: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'space-around',
+    width: '100%',
+    paddingBottom: 16,
+  },
+  inputWrapper: {
+    width: '100%',
+  },
+});

--- a/components/onboarding/steps/GrowthStep.tsx
+++ b/components/onboarding/steps/GrowthStep.tsx
@@ -1,0 +1,67 @@
+import { Animated, StyleSheet, Text, View } from 'react-native';
+
+import { colors } from '@/constants/colors';
+
+import { GROWTH_PILLS } from '../onboarding-data';
+
+interface GrowthStepProps {
+  pillAnims: Animated.Value[];
+}
+
+export default function GrowthStep({ pillAnims }: GrowthStepProps) {
+  return (
+    <View style={styles.pillsWrapper}>
+      {GROWTH_PILLS.map((label, index) => (
+        <Animated.View
+          key={label}
+          style={{
+            opacity: pillAnims[index],
+            transform: [
+              {
+                scale: pillAnims[index].interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [0.75, 1],
+                }),
+              },
+              {
+                translateY: pillAnims[index].interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [24, 0],
+                }),
+              },
+            ],
+          }}
+        >
+          <View style={styles.pill}>
+            <Text style={styles.pillText}>{label}</Text>
+          </View>
+        </Animated.View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  pillsWrapper: {
+    flex: 1,
+    justifyContent: 'center',
+    gap: 16,
+    width: '80%',
+  },
+  pill: {
+    backgroundColor: colors.primary[500],
+    borderRadius: 50,
+    paddingVertical: 20,
+    alignItems: 'center',
+    shadowColor: colors.primary[600],
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.25,
+    shadowRadius: 8,
+    elevation: 4,
+  },
+  pillText: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: '700',
+  },
+});

--- a/components/onboarding/steps/LevelStep.tsx
+++ b/components/onboarding/steps/LevelStep.tsx
@@ -1,0 +1,26 @@
+import { Animated } from 'react-native';
+
+import LevelList from '../LevelList';
+
+interface LevelStepProps {
+  selectedLevel: string | null;
+  levelAnims: Animated.Value[];
+  levelScales: Animated.Value[];
+  onSelectLevel: (id: string, index: number) => void;
+}
+
+export default function LevelStep({
+  selectedLevel,
+  levelAnims,
+  levelScales,
+  onSelectLevel,
+}: LevelStepProps) {
+  return (
+    <LevelList
+      selectedLevel={selectedLevel}
+      levelAnims={levelAnims}
+      levelScales={levelScales}
+      onSelectLevel={onSelectLevel}
+    />
+  );
+}

--- a/components/onboarding/useOnboardingAnimations.ts
+++ b/components/onboarding/useOnboardingAnimations.ts
@@ -1,0 +1,110 @@
+import { Dispatch, SetStateAction, useEffect, useMemo, useRef } from 'react';
+import { Animated } from 'react-native';
+
+export function useOnboardingAnimations(step: number) {
+  const fadeAnim = useRef(new Animated.Value(1)).current;
+  const slideAnim = useRef(new Animated.Value(0)).current;
+  const floatAnim = useRef(new Animated.Value(0)).current;
+
+  const pillAnims = useMemo(() => createAnimatedValues(3, 0), []);
+  const cashAnims = useMemo(() => createAnimatedValues(3, 0), []);
+  const levelAnims = useMemo(() => createAnimatedValues(3, 0), []);
+  const levelScales = useMemo(() => createAnimatedValues(3, 1), []);
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(floatAnim, { toValue: -12, duration: 1800, useNativeDriver: true }),
+        Animated.timing(floatAnim, { toValue: 0, duration: 1800, useNativeDriver: true }),
+      ])
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [floatAnim]);
+
+  useEffect(() => {
+    const animatePills = () => {
+      pillAnims.forEach((anim) => anim.setValue(0));
+      Animated.stagger(
+        140,
+        pillAnims.map((anim) =>
+          Animated.spring(anim, { toValue: 1, tension: 90, friction: 8, useNativeDriver: true })
+        )
+      ).start();
+    };
+
+    const animateCash = () => {
+      cashAnims.forEach((anim) => anim.setValue(0));
+      Animated.stagger(
+        120,
+        cashAnims.map((anim) =>
+          Animated.spring(anim, { toValue: 1, tension: 80, friction: 7, useNativeDriver: true })
+        )
+      ).start();
+    };
+
+    const animateLevels = () => {
+      levelAnims.forEach((anim) => anim.setValue(0));
+      Animated.stagger(
+        100,
+        levelAnims.map((anim) =>
+          Animated.timing(anim, { toValue: 1, duration: 320, useNativeDriver: true })
+        )
+      ).start();
+    };
+
+    if (step === 1) {
+      animatePills();
+    }
+    if (step === 2) {
+      animateCash();
+    }
+    if (step === 3) {
+      animateLevels();
+    }
+  }, [cashAnims, levelAnims, pillAnims, step]);
+
+  const goToStep = (next: number, setStep: Dispatch<SetStateAction<number>>) => {
+    const direction = next > step ? -24 : 24;
+
+    Animated.parallel([
+      Animated.timing(fadeAnim, { toValue: 0, duration: 160, useNativeDriver: true }),
+      Animated.timing(slideAnim, { toValue: direction, duration: 160, useNativeDriver: true }),
+    ]).start(() => {
+      setStep(next);
+      slideAnim.setValue(-direction);
+      Animated.parallel([
+        Animated.timing(fadeAnim, { toValue: 1, duration: 260, useNativeDriver: true }),
+        Animated.timing(slideAnim, { toValue: 0, duration: 260, useNativeDriver: true }),
+      ]).start();
+    });
+  };
+
+  const animateLevelSelect = (index: number) => {
+    Animated.sequence([
+      Animated.timing(levelScales[index], { toValue: 0.96, duration: 80, useNativeDriver: true }),
+      Animated.spring(levelScales[index], {
+        toValue: 1,
+        tension: 200,
+        friction: 10,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  };
+
+  return {
+    fadeAnim,
+    slideAnim,
+    floatAnim,
+    pillAnims,
+    cashAnims,
+    levelAnims,
+    levelScales,
+    goToStep,
+    animateLevelSelect,
+  };
+}
+
+function createAnimatedValues(count: number, initialValue: number) {
+  return Array.from({ length: count }, () => new Animated.Value(initialValue));
+}


### PR DESCRIPTION
## 📝 작업 내용
- 온보딩 스크린 구현
- 로그인 후 온보딩 화면으로 이동하도록 라우팅 연결

---

## 🔄 변경 사항
- 캐릭터 이름 설정, 성장 메커니즘 설명, 캐시 제도 설명, 난이도 선택 온보딩 단계 추가
- 난이도 선택 리스트 컴포넌트 분리
- 온보딩 단계 인디케이터, 하단 버튼, 애니메이션 로직 분리
- `login` 이후 `/onboarding`으로 이동하도록 수정
- `onboarding` 라우트를 스택에 등록
- 미사용 코드 제거

---

## 🔗 관련 이슈
- #14 

